### PR TITLE
Expose request params

### DIFF
--- a/IPC/Base.php
+++ b/IPC/Base.php
@@ -62,6 +62,16 @@ abstract class Base
     }
 
     /**
+     * Get API request params
+     *
+     * @return array
+     */
+    public function getParams()
+    {
+        return $this->params + ['Signature' => $this->_createSignature()];
+    }
+
+    /**
      * Add API request param
      *
      * @param string $paramName

--- a/IPC/PreAuthorization.php
+++ b/IPC/PreAuthorization.php
@@ -108,12 +108,13 @@ class PreAuthorization extends Base
     }
 
     /**
-     * Initiate API request
+     * Initiate API request params
      *
-     * @return boolean
+     * @return PreAuthorization
+     *
      * @throws IPC_Exception
      */
-    public function process()
+    public function processParams()
     {
         $this->validate();
 
@@ -136,6 +137,19 @@ class PreAuthorization extends Base
         $this->_addPostParam('URL_Notify', $this->getUrlNotify());
 
         $this->_addPostParam('Note', $this->getNote());
+
+        return $this;
+    }
+
+    /**
+     * Initiate API request
+     *
+     * @return boolean
+     * @throws IPC_Exception
+     */
+    public function process()
+    {
+        $this->processParams();
 
         $this->_processHtmlPost();
 

--- a/IPC/Purchase.php
+++ b/IPC/Purchase.php
@@ -119,12 +119,13 @@ class Purchase extends Base
     }
 
     /**
-     * Initiate API request
+     * Initiate API request params
      *
-     * @return boolean
+     * @return Purchase
+     *
      * @throws IPC_Exception
      */
-    public function process()
+    public function processParams()
     {
         $this->validate();
 
@@ -176,6 +177,19 @@ class Purchase extends Base
         $this->_addPostParam('CardTokenRequest', $this->getCardTokenRequest());
         $this->_addPostParam('PaymentParametersRequired', $this->getPaymentParametersRequired());
         $this->_addPostParam('PaymentMethod', $this->getPaymentMethod());
+
+        return $this;
+    }
+
+    /**
+     * Initiate API request
+     *
+     * @return boolean
+     * @throws IPC_Exception
+     */
+    public function process()
+    {
+        $this->processParams();
 
         $this->_processHtmlPost();
 

--- a/IPC/PurchaseByIcard.php
+++ b/IPC/PurchaseByIcard.php
@@ -116,14 +116,14 @@ class PurchaseByIcard extends Base
         return $this;
     }
 
-
     /**
-     * Initiate API request
+     * Initiate API request params
      *
-     * @return boolean
+     * @return PurchaseByIcard
+     *
      * @throws IPC_Exception
      */
-    public function process()
+    public function processParams()
     {
         $this->validate();
 
@@ -157,6 +157,20 @@ class PurchaseByIcard extends Base
             $this->_addPostParam('Currency_' . $i, $this->getCurrency());
             $i++;
         }
+
+        return $this;
+    }
+
+    /**
+     * Initiate API request
+     *
+     * @return boolean
+     * @throws IPC_Exception
+     */
+    public function process()
+    {
+        $this->processParams();
+
         $this->_processHtmlPost();
 
         return true;


### PR DESCRIPTION
## Issue

We're working on Drupal Commerce module to implement the myPOS payment gateway.

The current payment page process output markup directly and exit the PHP process which raises many issue:
- The code only works with javascript enabled, without it it will only output a blank page.
- It outputs only a blank page while we would prefer to display a branded page waiting for the redirect to occur, which can take some time in low-bandwith contexts
- It exits the PHP process while we might want to have better control over the page rendering

## Proposed solution

This PR proposes to expose the request parameters to developers that want better control over the redirect behaviour. The new method `getParams` gather request parameters and signed them, then the developer has to handle the redirection. It has no breaking changes regarding the current default process.